### PR TITLE
Invalid catch expression

### DIFF
--- a/src/emagick.erl
+++ b/src/emagick.erl
@@ -60,7 +60,7 @@ with(InData, From, Funs, AppEnv) ->
     % Res = call_funs(Funs, {InFile, AppEnv}),
     try lists:foldl(fun (Fun, Arg) -> Fun(Arg) end, {InFile, [{filename, Filename}, {from, From} | AppEnv]}, Funs) of
         Res -> Res
-    catch Err -> {error, Err}
+    catch _:Err -> {error, binary:part(list_to_binary(io_lib:format("~p", [E])), {0, 50})}
     after
         file:delete(InFile)
     end.

--- a/src/emagick.erl
+++ b/src/emagick.erl
@@ -60,7 +60,7 @@ with(InData, From, Funs, AppEnv) ->
     % Res = call_funs(Funs, {InFile, AppEnv}),
     try lists:foldl(fun (Fun, Arg) -> Fun(Arg) end, {InFile, [{filename, Filename}, {from, From} | AppEnv]}, Funs) of
         Res -> Res
-    catch _:Err -> {error, binary:part(list_to_binary(io_lib:format("~p", [E])), {0, 50})}
+    catch _:Err -> {error, binary:part(list_to_binary(io_lib:format("~p", [Err])), {0, 50})}
     after
         file:delete(InFile)
     end.


### PR DESCRIPTION
Hi Manuel, please rollback my previos pullrequest from 'handling_non-zero_exit_status' . It was not correct as the component design supposed to throw exception but not passing operation status through the operation chain .

Simply there was invalid catch expression that is fixed , see the code delta :) sorry for trouble
